### PR TITLE
Add missing CursorColumn line to the quickstart.

### DIFF
--- a/examples/lush_quickstart.lua
+++ b/examples/lush_quickstart.lua
@@ -102,6 +102,7 @@ local theme = lush(function()
 
     -- We can also link a group to another group. These will inherit all of the
     -- linked group options (See h: hi-link). (`setlocal cursorcolumn`)
+    -- CursorColumn { CursorLine },
 
     -- Here's how we can set comments to be slightly less visible and italic.
     -- (italics are terminal support dependent)


### PR DESCRIPTION
Thanks for this plugin, it's something desperately needed.  Manually reloading colors was extremely tedious even for the very simple theme's I've made.  I dreamed of darken/lighten.  This looks amazing.