### PR TITLE
readme: Fix inheritance example in cool_name.lua.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ return lush(function()
     -- Note you must define Normal before you try to use it.
     Whitespace { fg = Normal.fg.darken(40) },
     -- And make comments look the same, but with italic text
-    Comment { Comment, gui="italic" },
+    Comment { Whitespace, gui="italic" },
     -- and clear all highlighting for CursorLine
     CursorLine { },
   }


### PR DESCRIPTION
Comment was deriving from itself, rather than from Whitespace.  Looks like it was just a mix-up during some refactoring.