### PR TITLE
Update LSP highlight groups in template (and minor fix to spell hl-groups)

### DIFF
--- a/examples/lush-template/lua/lush_theme/lush_template.lua
+++ b/examples/lush-template/lua/lush_theme/lush_template.lua
@@ -169,21 +169,35 @@ local theme = lush(function()
     -- These groups are for the native LSP client. Some other LSP clients may use
     -- these groups, or use their own. Consult your LSP client's documentation.
 
-    -- LspDiagnosticsError               { }, -- used for "Error" diagnostic virtual text
-    -- LspDiagnosticsErrorSign           { }, -- used for "Error" diagnostic signs in sign column
-    -- LspDiagnosticsErrorFloating       { }, -- used for "Error" diagnostic messages in the diagnostics float
-    -- LspDiagnosticsWarning             { }, -- used for "Warning" diagnostic virtual text
-    -- LspDiagnosticsWarningSign         { }, -- used for "Warning" diagnostic signs in sign column
-    -- LspDiagnosticsWarningFloating     { }, -- used for "Warning" diagnostic messages in the diagnostics float
-    -- LspDiagnosticsInformation         { }, -- used for "Information" diagnostic virtual text
-    -- LspDiagnosticsInformationSign     { }, -- used for "Information" signs in sign column
-    -- LspDiagnosticsInformationFloating { }, -- used for "Information" diagnostic messages in the diagnostics float
-    -- LspDiagnosticsHint                { }, -- used for "Hint" diagnostic virtual text
-    -- LspDiagnosticsHintSign            { }, -- used for "Hint" diagnostic signs in sign column
-    -- LspDiagnosticsHintFloating        { }, -- used for "Hint" diagnostic messages in the diagnostics float
-    -- LspReferenceText                  { }, -- used for highlighting "text" references
-    -- LspReferenceRead                  { }, -- used for highlighting "read" references
-    -- LspReferenceWrite                 { }, -- used for highlighting "write" references
+    -- LspReferenceText                    { }; -- used for highlighting "text" references
+    -- LspReferenceRead                    { }; -- used for highlighting "read" references
+    -- LspReferenceWrite                   { }; -- used for highlighting "write" references
+
+    --LspDiagnosticsDefaultError           { }; -- Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
+    --LspDiagnosticsDefaultWarning         { }; -- Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
+    --LspDiagnosticsDefaultInformation     { }; -- Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
+    --LspDiagnosticsDefaultHint            { }; -- Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
+
+    --LspDiagnosticsVirtualTextError       { }; -- Used for "Error" diagnostic virtual text
+    --LspDiagnosticsVirtualTextWarning     { }; -- Used for "Warning" diagnostic virtual text
+    --LspDiagnosticsVirtualTextInformation { }; -- Used for "Information" diagnostic virtual text
+    --LspDiagnosticsVirtualTextHint        { }; -- Used for "Hint" diagnostic virtual text
+
+    --LspDiagnosticsUnderlineError         { }; -- Used to underline "Error" diagnostics
+    --LspDiagnosticsUnderlineWarning       { }; -- Used to underline "Warning" diagnostics
+    --LspDiagnsticsUnderlineInformation    { }; -- Used to underline "Information" diagnostics
+    --LspDiagnosticsUnderlineHint          { }; -- Used to underline "Hint" diagnostics
+
+    --LspDiagnosticsFloatingError          { }; -- Used to color "Error" diagnostic messages in diagnostics float
+    --LspDiagnosticsFloatingWarning        { }; -- Used to color "Warning" diagnostic messages in diagnostics float
+    --LspDiagnosticsFloatingInformation    { }; -- Used to color "Information" diagnostic messages in diagnostics float
+    --LspDiagnosticsFloatingHint           { }; -- Used to color "Hint" diagnostic messages in diagnostics float
+
+    --LspDiagnosticsSignError              { }; -- Used for "Error" signs in sign column
+    --LspDiagnosticsSignWarning            { }; -- Used for "Warning" signs in sign column
+    --LspDiagnosticsSignInformation        { }; -- Used for "Information" signs in sign column
+    --LspDiagnosticsSignHint               { }; -- Used for "Hint" signs in sign column
+
 
     -- These groups are for the neovim tree-sitter highlights.
     -- As of writing, tree-sitter support is a WIP, group names may change.

--- a/examples/lush-template/lua/lush_theme/lush_template.lua
+++ b/examples/lush-template/lua/lush_theme/lush_template.lua
@@ -99,7 +99,10 @@ local theme = lush(function()
     -- Question     { }, -- |hit-enter| prompt and yes/no questions
     -- QuickFixLine { }, -- Current |quickfix| item in the quickfix window. Combined with |hl-CursorLine| when the cursor is there.
     -- Search       { }, -- Last search pattern highlighting (see 'hlsearch').  Also used for similar items that need to stand out.
-    -- SpecialKey   { }, -- Unprintable characters: text displayed differently from what it really is.  But not 'listchars' whitespace. |hl-Whitespace| SpellBad  Word that is not recognized by the spellchecker. |spell| Combined with the highlighting used otherwise.  SpellCap  Word that should start with a capital. |spell| Combined with the highlighting used otherwise.  SpellLocal  Word that is recognized by the spellchecker as one that is used in another region. |spell| Combined with the highlighting used otherwise.
+    -- SpecialKey   { }, -- Unprintable characters: text displayed differently from what it really is.  But not 'listchars' whitespace. |hl-Whitespace|
+    -- SpellBad     { }, -- Word that is not recognized by the spellchecker. |spell| Combined with the highlighting used otherwise.
+    -- SpellCap     { }, -- Word that should start with a capital. |spell| Combined with the highlighting used otherwise.
+    -- SpellLocal   { }, -- Word that is recognized by the spellchecker as one that is used in another region. |spell| Combined with the highlighting used otherwise.
     -- SpellRare    { }, -- Word that is recognized by the spellchecker as one that is hardly ever used.  |spell| Combined with the highlighting used otherwise.
     -- StatusLine   { }, -- status line of current window
     -- StatusLineNC { }, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.


### PR DESCRIPTION
The built-in LSP now has more highlight groups (and renamed some old ones).

I think those were added when LSP-diagnostics was moved to core, but I'm not sure. Anyways, these are the ones listed in the current docs (nightly).

----
There was also a small problem with the `spell` highlight groups. I made a separate commit for that.