### PR TITLE
fix(compiler): Illegal value: blend=NONE

### DIFF
--- a/lua/lush/compiler.lua
+++ b/lua/lush/compiler.lua
@@ -15,6 +15,10 @@ local function make_group(name, opts)
   local gui = opts.gui or 'NONE'
   gui = string.gsub(gui, ' ', '')
 
+  if gui == '' then
+    gui = 'NONE'
+  end
+
   return table.concat({
     'highlight ' .. name,
     'guifg=' .. (opts.fg or 'NONE'),


### PR DESCRIPTION
fixup "E418: Illegal value: blend=NONE" error if gui is empty string


see https://github.com/npxbr/gruvbox.nvim/issues/30

Or we should not put `gui` to the `highlight` command if `gui` is empty string ?