### PR TITLE
Pass options to compiler

### DIFF
--- a/lua/lush.lua
+++ b/lua/lush.lua
@@ -50,7 +50,7 @@ end
 
 -- table -> table
 M.compile = function(ast, options)
-  local compiled = compiler(ast)
+  local compiled = compiler(ast, options)
 
   if options and options.force_clean then
     compiled = insert_force_clean(compiled)

--- a/spec/user_bugs_spec.moon
+++ b/spec/user_bugs_spec.moon
@@ -43,3 +43,16 @@ describe "user bugs", ->
       -- compiler converts to none
       compiled = compile(parsed)
       assert.matches("guibg=NONE", compiled[1])
+
+  describe "key exclusion in compile", ->
+    -- https://github.com/rktjmp/lush.nvim/pull/65
+    it "can exclude keys", ->
+        ast = parse -> {
+        A { gui: "italic", blend: 40 }
+        }
+        compiled = compile(ast, {
+        exclude_keys: {"blend"}
+        })
+        assert.is_not_nil(compiled)
+        assert.matches("italic", compiled[1])
+        assert.not.matches("blend", compiled[1])


### PR DESCRIPTION
Fixes `exclude_keys` not working.