### PR TITLE
Remove syntax reset

### DIFF
--- a/lua/lush.lua
+++ b/lua/lush.lua
@@ -17,7 +17,6 @@ end
 local insert_force_clean = function(compiled_ast)
     local clean = {
       "hi clear",
-      "syntax reset",
       "set t_Co=256",
     }
     if vim.g.colors_name then

--- a/spec/lush_spec.moon
+++ b/spec/lush_spec.moon
@@ -85,7 +85,7 @@ describe "lush", ->
     parsed = lush(lush_spec)
     text = lush.stringify(parsed)
     assert.is_string(text)
-    assert.is_equal(7, select(2, string.gsub(text, '\n', '\n')))
+    assert.is_equal(6, select(2, string.gsub(text, '\n', '\n')))
     -- options
     parsed = lush(lush_spec)
     text = lush.stringify(parsed, {force_clean: false})


### PR DESCRIPTION
It's been observed that `syntax reset` is not necessary anymore. Ref: https://github.com/vim/colorschemes/issues/34

With the line, `syncolor.vim` is loaded twice. If anything it might improve the startup a tiny tiny bit.