### PR TITLE
Add missing Commas to sample scripts

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -86,7 +86,7 @@ run(colorscheme,
   --
   -- append() accepts a table of values, or one value, so this call ends up being:
   -- append(last_pipe_value, {"set...",  "let..."})
-  {append {"set background=dark", "let g:colors_name=\"my_colorscheme\""}},
+  {append, {"set background=dark", "let g:colors_name=\"my_colorscheme\""}},
 
   -- now we are ready to write our colors file. note: there is no reason this has
   -- to be written to the relative "colors" dir, you could write the file to an
@@ -124,7 +124,7 @@ run(require("colorscheme"),
   -- write the lua code into our destination.
   -- you must specify open and close markers yourself to account
   -- for differing comment styles, patchwrite isn't limited to lua files.
-  {patchwrite "colors/colorscheme.lua", "-- PATCH_OPEN", "-- PATCH_CLOSE"})
+  {patchwrite, "colors/colorscheme.lua", "-- PATCH_OPEN", "-- PATCH_CLOSE"})
 ```
 
 </details>


### PR DESCRIPTION
I was trying to run Shipwright on my custom theme and it kept throwing an error. I copied/pasted the script here, so hopefully this saves someone in the future some hassle :).

The error thrown was that in builder.lua on line 38 when it tries to call func
```
E5108: Error executing lua ...ite/pack/packer/start/shipwright.nvim/lua/shipwright.lua:18: .../packer/start/shipwright.nvim/lua/shipwright/builder.lua:38: attempt to call local 'func' (a table value)              
stack traceback:                                                                                                                                                                                                     
        [C]: in function 'assert'                                                                                                                                                                                    
        ...ite/pack/packer/start/shipwright.nvim/lua/shipwright.lua:18: in function 'build'                                                                                                                          
        [string ":lua"]:1: in main chunk 
```

this was my run command
```
local colorscheme = require("my.theme.name")
local lushwright = require("shipwright.transform.lush")


run(colorscheme,
    lushwright.to_vimscript,
    {append {"set bg=dark", "let g:colors_name=\"theme_name\""}},
    {overwrite, "path/to/output.vim"})
```
After adding the comma after `append` the error went away.