### PR TITLE
Trigger `ColorScheme` autocmd during `:Lushify`

### DIFF
--- a/lua/lush/ify.lua
+++ b/lua/lush/ify.lua
@@ -255,6 +255,7 @@ local function eval_buffer(buf)
       -- hang around.
       print(" ") -- clear error
       did_apply = true
+      vim.api.nvim_exec_autocmds("ColorScheme", {})
     end
   end
 


### PR DESCRIPTION
Some plugins relies on the `ColorScheme` autocmd to do some special things with the highlights.
Without triggering this autocmd, `:Lushify` _might_ not give an accurate representation of how the theme will actually look like when you call it with `:colorscheme`.