### PR TITLE
Include more folders in rockspec build steps

### DIFF
--- a/lush.nvim-scm-1.rockspec
+++ b/lush.nvim-scm-1.rockspec
@@ -7,8 +7,8 @@ description = {
 	summary = "Define Neovim themes as a DSL in lua, with real-time feedback.",
 	labels = { "neovim" },
 	detailed = [[
-    Lush is a colorscheme creation aid, written in Lua, for Neovim.
-   ]],
+		Lush is a colorscheme creation aid, written in Lua, for Neovim.
+	]],
 	homepage = "https://github.com/rktjmp/lush.nvim",
 	license = "MIT/X11",
 }
@@ -30,10 +30,14 @@ end
 
 build = {
 	type = "builtin",
-    copy_directories = {
-        "doc"
-    }
+	copy_directories = {
+		"doc",
+		"examples",
+		"plugin",
+		"spec",
+	}
 }
+
 test_dependencies = {
 	"moonscript",
 }


### PR DESCRIPTION
## Description
This fixes the build via rockspec when installing the plugin through [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/applications/editors/vim/plugins/generated.nix#L4992).
Indeed, if the directories are not included, they will not be copied over the installation path.

Also fixed minor tab/space inconsistencies.

## Before the patch

### Installation path files

![lush-nvim-before-path](https://github.com/rktjmp/lush.nvim/assets/26801023/a86b60f7-8e8f-4d2d-94f5-e16abcdd25e3)

### Example vim command

![lush-nvim-before](https://github.com/rktjmp/lush.nvim/assets/26801023/0a078ea7-d8e3-4a2f-a706-3681d3ba43bb)


## After applying the patch

### Installation path files

![lush-nvim-after-path](https://github.com/rktjmp/lush.nvim/assets/26801023/bf8cbfdb-367d-4c3d-aab0-0cf127ea7fe0)

### Example vim command

![lush-nvim-after](https://github.com/rktjmp/lush.nvim/assets/26801023/fb3c114d-da7a-4796-bcc1-5a32839eb1ac)
