### PR TITLE
Improve highlight of compact calls

### DIFF
--- a/lua/lush/ify.lua
+++ b/lua/lush/ify.lua
@@ -26,8 +26,8 @@ end
 --       low impact.
 local function set_highlight_groups_on_line(buf, line, line_num)
   local group =
-      string.match(line, "%s-(%a[%a%d_]-)%s-{") or
-      string.match(line, [[%s-(sym%(?["'][%a%d%.@]+["']%)?)%s-{]])
+      string.match(line, "%s-(%a[%a%d_]-)%s-[{%(]") or
+      string.match(line, [=[%s-(sym%(?["'][%a%d%.@]+["']%)?)%s-[{%(]]=])
 
   if group then
     -- technically, find matches the first occurrence in line, but this should

--- a/lua/lush/ify.lua
+++ b/lua/lush/ify.lua
@@ -26,8 +26,8 @@ end
 --       low impact.
 local function set_highlight_groups_on_line(buf, line, line_num)
   local group =
-      string.match(line, [=[%s-(sym%(?["'][%a%d%.@]+["']%)?)%s-[{%(]]=]) or
-      string.match(line, "%s-(%a[%a%d_]-)%s-[{%(]")
+    string.match(line, [=[%s-(sym%(?["'][%a%d%.@]+["']%)?)%s-[{%(]]=])
+      or string.match(line, "%s-(%a[%a%d_]-)%s-[{%(]")
 
   if group then
     -- technically, find matches the first occurrence in line, but this should

--- a/lua/lush/ify.lua
+++ b/lua/lush/ify.lua
@@ -26,8 +26,8 @@ end
 --       low impact.
 local function set_highlight_groups_on_line(buf, line, line_num)
   local group =
-      string.match(line, "%s-(%a[%a%d_]-)%s-[{%(]") or
-      string.match(line, [=[%s-(sym%(?["'][%a%d%.@]+["']%)?)%s-[{%(]]=])
+      string.match(line, [=[%s-(sym%(?["'][%a%d%.@]+["']%)?)%s-[{%(]]=]) or
+      string.match(line, "%s-(%a[%a%d_]-)%s-[{%(]")
 
   if group then
     -- technically, find matches the first occurrence in line, but this should


### PR DESCRIPTION
This PR does two things:
1. enables highlighting of parenthesized calls, so that reusing/aliasing highlight groups becomes easier and less noisy
2. fixes a bug that caused highlight groups that make use of the `sym("@foo.bar")`-format not highlight correctly

----

1. While it is functionally already possible to set one highlight group using another, isn't properly rendered in the active preview. This is because the regex explicitly looks for a `{` - allowing an opening parentheses fixes this.
```lua
    ...
    Type              { fg = some_color, bg = some_other_color, gui = some_setting },
    StorageClass      ( Type ), -- this now highlights "StorageClass" properly
    
    
     -- this works on current main, but is noisy and prone to copy/paste mistakes
    Structure         { fg = Type.fg, bg = Type.bg, gui = Type.gui }, 
    ...
```
Here it is in action, where I have predefined some highlights in a table called `Q`:
<img width="367" height="187" alt="image" src="https://github.com/user-attachments/assets/b1312639-a330-4f30-9e30-3d67b74304bb" />

---

2. AFAIU, the regex capturing "regular" syntax groups is broader than the one capturing `sym`-based groups. This means they were never highlighted correctly. Reordering them to check the more narrowly defined regex first fixes this issue:   
<img width="624" height="252" alt="image" src="https://github.com/user-attachments/assets/80d23ab0-4f22-4292-94de-c068c5e5d2c5" />
